### PR TITLE
[Feat] 추가 수정사항 반영

### DIFF
--- a/src/api/store/types.ts
+++ b/src/api/store/types.ts
@@ -1,5 +1,6 @@
 export interface Store {
   store_id: string;
+  store_number: number;
   store_name: string;
   store_location: string;
   store_size: string;

--- a/src/app/api/store/route.ts
+++ b/src/app/api/store/route.ts
@@ -28,7 +28,12 @@ export async function GET(req: NextRequest) {
     query = query.gte('store_cost', parseInt(parsedBudget[0]));
   }
   if (location) query = query.eq('store_location', location);
-  if (search) query = query.ilike('store_name', `%${search}%`);
+  if (search) {
+    const searchQueryStr = isNaN(parseInt(search))
+      ? `${StoresColumn.STORE_NAME}.ilike.%${search}%,${StoresColumn.DESCRIPTION}.ilike.%${search}%`
+      : `${StoresColumn.STORE_NAME}.ilike.%${search}%,${StoresColumn.DESCRIPTION}.ilike.%${search}%,${StoresColumn.STORE_NUMBER}.eq.${search}`;
+    query = query.or(searchQueryStr);
+  }
 
   query = query
     .eq('deleted', 'FALSE')

--- a/src/app/api/types.ts
+++ b/src/app/api/types.ts
@@ -17,6 +17,7 @@ export enum SupabaseTable {
 export enum StoresColumn {
   STORE_ID = 'store_id',
   STORE_NAME = 'store_name',
+  STORE_NUMBER = 'store_number',
   STORE_LOCATION = 'store_location',
   STORE_SIZE = 'store_size',
   STORE_CATEGORY = 'store_category',

--- a/src/app/store/[id]/page.tsx
+++ b/src/app/store/[id]/page.tsx
@@ -43,6 +43,7 @@ const StoreDetailPage = ({ params }: StoreDetailPageProps) => {
         ['임대료', storeDetailData.rent_cost],
         ['공과금', storeDetailData.dues_cost],
         ['기타잡비', storeDetailData.etc_cost],
+        ['월 수익', storeDetailData.monthly_revenue],
       ]
     : [];
 

--- a/src/app/store/[id]/page.tsx
+++ b/src/app/store/[id]/page.tsx
@@ -96,15 +96,31 @@ const StoreDetailPage = ({ params }: StoreDetailPageProps) => {
         px: isDownMedium ? 2 : 0,
       }}
     >
-      <Typography
-        variant={isDownMedium ? 'h6' : 'h4'}
-        component='h4'
-        fontWeight='bold'
-        align='center'
-        sx={{ mt: isDownMedium ? 5 : 8, mb: isDownMedium ? 2 : 3 }}
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          mt: isDownMedium ? 5 : 8,
+          mb: isDownMedium ? 2 : 3,
+        }}
       >
-        {storeDetailData?.store_name}
-      </Typography>
+        <Typography
+          variant={isDownMedium ? 'h6' : 'h4'}
+          component='h4'
+          fontWeight='bold'
+          align='center'
+        >
+          [ 매물번호 {storeDetailData?.store_number} ]
+        </Typography>
+        <Typography
+          variant={isDownMedium ? 'h6' : 'h4'}
+          component='h4'
+          fontWeight='bold'
+          align='center'
+        >
+          {storeDetailData?.store_name}
+        </Typography>
+      </Box>
       <ParagraphDivider />
       <StoreDetailContent
         storeDetailData={storeDetailData}

--- a/src/components/admin/store/StoreDataGrid.tsx
+++ b/src/components/admin/store/StoreDataGrid.tsx
@@ -10,6 +10,7 @@ import type { GridColDef } from '@mui/x-data-grid';
 
 const columns: GridColDef[] = [
   { field: StoreColumnDef.ID, headerName: 'ID', width: 90 },
+  { field: StoreColumnDef.STORE_NUMBER, headerName: '매물 번호', width: 90 },
   {
     field: StoreColumnDef.STORE_NAME,
     headerName: '매물 이름',
@@ -68,6 +69,7 @@ const StoreDataGrid = () => {
 
     const parsedStore = data?.data.map((storeData) => ({
       [StoreColumnDef.ID]: storeData.store_id,
+      [StoreColumnDef.STORE_NUMBER]: storeData.store_number,
       [StoreColumnDef.STORE_NAME]: storeData.store_name,
       [StoreColumnDef.STORE_LOCATION]: storeData.store_location,
       [StoreColumnDef.STORE_CATEGORY]: storeData.store_category,

--- a/src/components/admin/store/constants.ts
+++ b/src/components/admin/store/constants.ts
@@ -1,5 +1,6 @@
 export enum StoreColumnDef {
   ID = 'id',
+  STORE_NUMBER = 'storeNumber',
   STORE_NAME = 'storeName',
   STORE_LOCATION = 'storeLocation',
   STORE_CATEGORY = 'storeCategory',

--- a/src/components/common/alt-image/AltImage.tsx
+++ b/src/components/common/alt-image/AltImage.tsx
@@ -1,7 +1,13 @@
+// props에 있는걸 인식 못해서 비활성화 함.
+/* eslint-disable jsx-a11y/alt-text */
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import Image from 'next/image';
+import { OFF_WHITE_COLOR } from '@/constants/color';
 
 interface AltImageProps {
-  src?: string;
+  src: string | undefined;
+  disableLabel?: boolean;
   alt: string;
   width?: number | `${number}` | undefined;
   height?: number | `${number}` | undefined;
@@ -17,10 +23,32 @@ interface AltImageProps {
   lazyBoundary?: string | undefined;
   lazyRoot?: string | undefined;
 }
-const AltImage = (props: AltImageProps) => {
-  // props에 있는걸 인식 못해서 비활성화 함.
-  // eslint-disable-next-line jsx-a11y/alt-text
-  return <Image src={props.src ? props.src : '/core-icon.png'} {...props} />;
+const AltImage = ({ src, disableLabel, ...props }: AltImageProps) => {
+  if (!src)
+    return (
+      <>
+        <Image src='/core-icon.png' {...props} />
+        <Box
+          sx={{
+            position: 'absolute',
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            backgroundColor: 'rgba(0,0,0,0.4)',
+          }}
+        >
+          {!disableLabel && (
+            <Typography color={OFF_WHITE_COLOR} variant='caption'>
+              표시할 이미지가 없습니다.
+            </Typography>
+          )}
+        </Box>
+      </>
+    );
+
+  return <Image src={src} {...props} />;
 };
 
 export default AltImage;

--- a/src/components/common/alt-image/AltImage.tsx
+++ b/src/components/common/alt-image/AltImage.tsx
@@ -1,0 +1,26 @@
+import Image from 'next/image';
+
+interface AltImageProps {
+  src?: string;
+  alt: string;
+  width?: number | `${number}` | undefined;
+  height?: number | `${number}` | undefined;
+  fill?: boolean | undefined;
+  quality?: number | `${number}` | undefined;
+  priority?: boolean | undefined;
+  loading?: 'eager' | 'lazy' | undefined;
+  blurDataURL?: string | undefined;
+  unoptimized?: boolean | undefined;
+  layout?: string | undefined;
+  objectFit?: string | undefined;
+  objectPosition?: string | undefined;
+  lazyBoundary?: string | undefined;
+  lazyRoot?: string | undefined;
+}
+const AltImage = (props: AltImageProps) => {
+  // props에 있는걸 인식 못해서 비활성화 함.
+  // eslint-disable-next-line jsx-a11y/alt-text
+  return <Image src={props.src ? props.src : '/core-icon.png'} {...props} />;
+};
+
+export default AltImage;

--- a/src/components/common/alt-image/index.ts
+++ b/src/components/common/alt-image/index.ts
@@ -1,0 +1,1 @@
+export { default as AltImage } from './AltImage';

--- a/src/components/common/mobile-store-card/MobileStoreCard.tsx
+++ b/src/components/common/mobile-store-card/MobileStoreCard.tsx
@@ -6,11 +6,11 @@ import CardActions from '@mui/material/CardActions';
 import CardMedia from '@mui/material/CardMedia';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { StoreCardProps } from '@/components/common/store-card/StoreCard';
 import { CorePointRoutes } from '@/constants/routes';
 import { convertMoneyString } from '@/utils';
+import { AltImage } from '../alt-image';
 import { BoldLabelValue } from '../store-card/elements';
 
 const MobileStoreCard = ({
@@ -66,12 +66,12 @@ const MobileStoreCard = ({
               mb: 1,
             }}
           >
-            <Image
+            <AltImage
               fill
               src={
                 storeData?.store_img_src_arr
                   ? storeData?.store_img_src_arr[0]
-                  : ''
+                  : '/core-icon.png'
               }
               alt={storeData?.store_name + ' image'}
             />

--- a/src/components/common/mobile-store-card/MobileStoreCard.tsx
+++ b/src/components/common/mobile-store-card/MobileStoreCard.tsx
@@ -71,7 +71,7 @@ const MobileStoreCard = ({
               src={
                 storeData?.store_img_src_arr
                   ? storeData?.store_img_src_arr[0]
-                  : '/core-icon.png'
+                  : undefined
               }
               alt={storeData?.store_name + ' image'}
             />

--- a/src/components/common/mobile-store-card/MobileStoreCard.tsx
+++ b/src/components/common/mobile-store-card/MobileStoreCard.tsx
@@ -48,7 +48,7 @@ const MobileStoreCard = ({
         onClick={() => handleCardClick(storeData?.store_id)}
       >
         <Typography variant='subtitle1' component='h4' sx={{ mt: 2 }}>
-          {storeData?.store_name}
+          [ 매물번호 {storeData?.store_number} ] {storeData?.store_name}
         </Typography>
         <Divider sx={{ width: '100%' }} />
         <Box sx={{ display: 'flex', mt: 1 }}>
@@ -112,7 +112,11 @@ const MobileStoreCard = ({
         <Button
           variant='contained'
           size='small'
-          onClick={() => handleConsultingClick(storeData?.store_name)}
+          onClick={() =>
+            handleConsultingClick(
+              `[ 매물번호 ${storeData.store_number} ] ${storeData.store_name}`,
+            )
+          }
         >
           창업컨설팅 신청
         </Button>

--- a/src/components/common/mobile-store-card/MobileStoreCard.tsx
+++ b/src/components/common/mobile-store-card/MobileStoreCard.tsx
@@ -114,7 +114,7 @@ const MobileStoreCard = ({
           size='small'
           onClick={() =>
             handleConsultingClick(
-              `[ 매물번호 ${storeData.store_number} ] ${storeData.store_name}`,
+              `[ 매물번호 ${storeData?.store_number} ] ${storeData?.store_name}`,
             )
           }
         >

--- a/src/components/common/store-card/StoreCard.tsx
+++ b/src/components/common/store-card/StoreCard.tsx
@@ -217,6 +217,9 @@ const StoreCard = (props: StoreCardProps) => {
             <CardActions sx={managerWrapperSx}>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
                 <Typography variant='subtitle2' fontWeight='bold'>
+                  [ 매물번호 {storeData?.store_number} ]
+                </Typography>
+                <Typography variant='subtitle2' fontWeight='bold'>
                   담당자 정보
                 </Typography>
                 <Typography variant='body2'>{storeData?.manager}</Typography>
@@ -227,7 +230,11 @@ const StoreCard = (props: StoreCardProps) => {
               <Button
                 variant='contained'
                 sx={{ whiteSpace: 'nowrap' }}
-                onClick={() => handleConsultingClick(storeData.store_name)}
+                onClick={() =>
+                  handleConsultingClick(
+                    `[ 매물번호 ${storeData.store_number} ] ${storeData.store_name}`,
+                  )
+                }
               >
                 창업컨설팅 신청
               </Button>

--- a/src/components/common/store-card/StoreCard.tsx
+++ b/src/components/common/store-card/StoreCard.tsx
@@ -12,12 +12,12 @@ import CardMedia from '@mui/material/CardMedia';
 import Skeleton from '@mui/material/Skeleton';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { Store } from '@/api/store';
 import { SMALL_LAYOUT_WIDTH } from '@/components/layout/general-layout/constants';
 import { CorePointRoutes } from '@/constants/routes';
 import { convertMoneyString } from '@/utils';
+import { AltImage } from '../alt-image';
 import { BoldLabelValue } from './elements';
 import type { SxProps } from '@mui/system';
 
@@ -28,13 +28,21 @@ const LARGE_CARD_HEIGHT = 200;
 const MANAGER_WIDTH = '180px';
 export interface StoreCardProps {
   storeData?: Store;
+  isLoading?: boolean;
   sx?: SxProps;
   handleStoreChange?: (newStoreName?: string) => void;
   openModal?: () => void;
   onCardClick?: () => void;
 }
 const StoreCard = (props: StoreCardProps) => {
-  const { storeData, sx, handleStoreChange, openModal, onCardClick } = props;
+  const {
+    storeData,
+    isLoading,
+    sx,
+    handleStoreChange,
+    openModal,
+    onCardClick,
+  } = props;
   const theme = useTheme();
   const router = useRouter();
   const isUpLarge = useMediaQuery(theme.breakpoints.up('lg'));
@@ -118,7 +126,10 @@ const StoreCard = (props: StoreCardProps) => {
       storeData.store_img_src_arr.length > 0
     ) {
       setImgSrc(storeData?.store_img_src_arr[0]);
+      return;
     }
+
+    setImgSrc('/core-icon.png');
   }, [storeData]);
 
   useEffect(() => {
@@ -148,16 +159,15 @@ const StoreCard = (props: StoreCardProps) => {
               onClick={() => handleCardClick(storeData?.store_id)}
             >
               <CardMedia sx={imgWrapperSx}>
-                {!imgSrc && (
+                {isLoading && (
                   <Skeleton variant='rounded' animation='wave' height='100%' />
                 )}
-                {imgSrc && (
-                  <Image
+                {!isLoading && (
+                  <AltImage
                     loading='lazy'
                     src={imgSrc}
                     fill
                     alt='store image'
-                    placeholder='blur'
                     blurDataURL='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg=='
                   />
                 )}

--- a/src/components/common/store-card/StoreCard.tsx
+++ b/src/components/common/store-card/StoreCard.tsx
@@ -128,8 +128,6 @@ const StoreCard = (props: StoreCardProps) => {
       setImgSrc(storeData?.store_img_src_arr[0]);
       return;
     }
-
-    setImgSrc('/core-icon.png');
   }, [storeData]);
 
   useEffect(() => {

--- a/src/components/common/store-card/StoreCard.tsx
+++ b/src/components/common/store-card/StoreCard.tsx
@@ -193,8 +193,8 @@ const StoreCard = (props: StoreCardProps) => {
                       <BoldLabelValue
                         label='매장 면적'
                         value={
-                          `${storeData?.store_size}평` +
-                          `(${storeData?.store_size_m2})`
+                          `${storeData?.store_size}평 / ` +
+                          `${storeData?.store_size_m2}m2`
                         }
                       />
                     </>

--- a/src/components/common/vertical-store-card/VerticalStoreCard.tsx
+++ b/src/components/common/vertical-store-card/VerticalStoreCard.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/navigation';
 import { Store } from '@/api/store';
 import { CorePointRoutes } from '@/constants/routes';
 import { convertMoneyString } from '@/utils';
+import { AltImage } from '../alt-image';
 import { BoldLabelValue } from '../store-card/elements';
 import type { SxProps, TypographyVariant } from '@mui/material';
 
@@ -53,18 +54,25 @@ const VerticalStoreCard = (props: VerticalStoreCardProps) => {
           onClick={() => handleCardClick(storeData?.store_id)}
         >
           <CardMedia
-            component='img'
             sx={{
+              flexGrow: 1,
+              flexShrink: 0,
+              position: 'relative',
               height: isSmall ? '120px' : '180px',
-              objectFit: 'cover',
+              width: '100%',
             }}
-            image={
-              Array.isArray(storeData?.store_img_src_arr)
-                ? storeData?.store_img_src_arr[0]
-                : undefined
-            }
-            alt='store image'
-          />
+          >
+            <AltImage
+              fill
+              objectFit='cover'
+              src={
+                Array.isArray(storeData?.store_img_src_arr)
+                  ? storeData?.store_img_src_arr[0]
+                  : '/core-icon.png'
+              }
+              alt='store image'
+            />
+          </CardMedia>
           <CardContent
             sx={{
               display: 'flex',

--- a/src/components/common/vertical-store-card/VerticalStoreCard.tsx
+++ b/src/components/common/vertical-store-card/VerticalStoreCard.tsx
@@ -82,7 +82,10 @@ const VerticalStoreCard = (props: VerticalStoreCardProps) => {
               alignItems: 'center',
             }}
           >
-            <Box>
+            <Box sx={{ display: 'flex', flexDirection: 'column', mb: 1 }}>
+              <Typography align='center' variant='caption'>
+                [ 매물번호 {storeData?.store_number} ]
+              </Typography>
               <Typography
                 align='center'
                 variant={cardTitleTypo}
@@ -106,18 +109,17 @@ const VerticalStoreCard = (props: VerticalStoreCardProps) => {
                 width: '100%',
                 height: '100%',
                 justifyContent: 'center',
-                alignItems: 'center',
               }}
             >
-              <BoldLabelValue
-                label={isSmall ? '비용' : '창업 비용'}
-                value={convertMoneyString(storeData?.store_cost)}
-                variant={cardTypo}
-              />
               <BoldLabelValue
                 primary
                 label='월 수익'
                 value={convertMoneyString(storeData?.monthly_revenue)}
+                variant={cardTypo}
+              />
+              <BoldLabelValue
+                label={isSmall ? '비용' : '창업 비용'}
+                value={convertMoneyString(storeData?.store_cost)}
                 variant={cardTypo}
               />
             </Box>

--- a/src/components/common/vertical-store-card/VerticalStoreCard.tsx
+++ b/src/components/common/vertical-store-card/VerticalStoreCard.tsx
@@ -68,7 +68,7 @@ const VerticalStoreCard = (props: VerticalStoreCardProps) => {
               src={
                 Array.isArray(storeData?.store_img_src_arr)
                   ? storeData?.store_img_src_arr[0]
-                  : '/core-icon.png'
+                  : undefined
               }
               alt='store image'
             />

--- a/src/components/consulting/opening/OpeningForm.tsx
+++ b/src/components/consulting/opening/OpeningForm.tsx
@@ -11,6 +11,8 @@ import { postOpeningConsulting } from '@/api/consulting/opening/postOpeningrCons
 import { PrivateAgreeLink } from '@/components/common/private-agree-link';
 import useSlideSnackBar from '@/components/common/slide-snackbar/useSlideSnackBar';
 import {
+  STORE_BUDGET_DATA_ARR,
+  STORE_BUDGET_MAPPER,
   STORE_CATEGORY_DATA_ARR,
   STORE_LOCATION_DATA_ARR,
 } from '@/components/store/constants';
@@ -154,7 +156,8 @@ const OpeningForm = ({ isDownLarge, initialValue }: OpeningFormProps) => {
               value={value}
               fullWidth
               onChange={(_, value) => onChange(value)}
-              options={STORE_CATEGORY_DATA_ARR}
+              getOptionLabel={(option) => STORE_BUDGET_MAPPER[option]}
+              options={STORE_BUDGET_DATA_ARR}
               renderInput={(params) => (
                 <TextField
                   {...params}

--- a/src/components/main/recommended-store/RecommendedStoreSwiper.tsx
+++ b/src/components/main/recommended-store/RecommendedStoreSwiper.tsx
@@ -57,7 +57,7 @@ const RecommendedStoreSwiper = () => {
         }}
         slidesPerView={slidePerView}
         modules={[Autoplay, Mousewheel, Navigation, Pagination]}
-        autoplay
+        // autoplay
         mousewheel
         loop
         pagination={{ clickable: true }}

--- a/src/components/store-detail/cost-detail/CostDetailSection.tsx
+++ b/src/components/store-detail/cost-detail/CostDetailSection.tsx
@@ -36,17 +36,12 @@ const CostDetailSection = ({
         parsedExpenditureData.map(([label, value], index) => (
           <ContainedListItem
             key={index + label}
+            primary={label === '월 수익'}
             size={continaedListSize}
             label={label}
             value={convertMoneyString(value)}
           />
         ))}
-      <ContainedListItem
-        size={continaedListSize}
-        primary
-        label='월 수익'
-        value={convertMoneyString(storeDetailData?.monthly_revenue)}
-      />
     </Box>
   );
 };

--- a/src/components/store-detail/image-section/ImageSection.tsx
+++ b/src/components/store-detail/image-section/ImageSection.tsx
@@ -80,6 +80,26 @@ const ImageSection = ({ imgSrcArr }: ImageSectionProps) => {
             </Card>
           </SwiperSlide>
         ))}
+        {imgSrcArr?.length === 0 && (
+          <SwiperSlide key={'swiper-gallery__img'}>
+            <Card
+              variant='elevation'
+              raised
+              sx={{
+                position: 'relative',
+                width: '100%',
+                height: '100%',
+              }}
+            >
+              <AltImage
+                objectFit='cover'
+                src={undefined}
+                alt='이미지 없음'
+                fill
+              />
+            </Card>
+          </SwiperSlide>
+        )}
       </Swiper>
       <Swiper
         style={thumbContainerStyle}
@@ -112,6 +132,27 @@ const ImageSection = ({ imgSrcArr }: ImageSectionProps) => {
             </Card>
           </SwiperSlide>
         ))}
+        {imgSrcArr?.length === 0 && (
+          <SwiperSlide key={'swiper-gallery__img'}>
+            <Card
+              variant='elevation'
+              raised
+              sx={{
+                position: 'relative',
+                width: '100%',
+                height: '100%',
+              }}
+            >
+              <AltImage
+                disableLabel
+                objectFit='cover'
+                src={undefined}
+                alt='이미지 없음'
+                fill
+              />
+            </Card>
+          </SwiperSlide>
+        )}
       </Swiper>
     </Box>
   );

--- a/src/components/store-detail/image-section/ImageSection.tsx
+++ b/src/components/store-detail/image-section/ImageSection.tsx
@@ -4,9 +4,9 @@ import { useEffect, useState } from 'react';
 import { useMediaQuery, useTheme } from '@mui/material';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
-import Image from 'next/image';
 import { FreeMode, Thumbs } from 'swiper/modules';
 import { Swiper, SwiperClass, SwiperSlide } from 'swiper/react';
+import { AltImage } from '@/components/common/alt-image';
 
 const LARGE_WIDTH = '500px';
 const LARGE_HEIGHT = '400px';
@@ -18,7 +18,7 @@ const SMALL_WIDTH = '250px';
 const SMALL_HEIGHT = '250px';
 
 interface ImageSectionProps {
-  imgSrcArr?: string[];
+  imgSrcArr?: string[] | undefined[];
 }
 const ImageSection = ({ imgSrcArr }: ImageSectionProps) => {
   const theme = useTheme();
@@ -76,7 +76,7 @@ const ImageSection = ({ imgSrcArr }: ImageSectionProps) => {
                 height: '100%',
               }}
             >
-              <Image objectFit='cover' src={imgSrc} alt='가게 이미지' fill />
+              <AltImage objectFit='cover' src={imgSrc} alt='가게 이미지' fill />
             </Card>
           </SwiperSlide>
         ))}
@@ -102,7 +102,13 @@ const ImageSection = ({ imgSrcArr }: ImageSectionProps) => {
                 height: '100%',
               }}
             >
-              <Image objectFit='cover' src={imgSrc} alt='가게 이미지' fill />
+              <AltImage
+                disableLabel
+                objectFit='cover'
+                src={imgSrc}
+                alt='가게 이미지'
+                fill
+              />
             </Card>
           </SwiperSlide>
         ))}

--- a/src/components/store-detail/image-section/ImageSection.tsx
+++ b/src/components/store-detail/image-section/ImageSection.tsx
@@ -76,7 +76,7 @@ const ImageSection = ({ imgSrcArr }: ImageSectionProps) => {
                 height: '100%',
               }}
             >
-              <Image src={imgSrc} alt='가게 이미지' fill />
+              <Image objectFit='cover' src={imgSrc} alt='가게 이미지' fill />
             </Card>
           </SwiperSlide>
         ))}
@@ -102,7 +102,7 @@ const ImageSection = ({ imgSrcArr }: ImageSectionProps) => {
                 height: '100%',
               }}
             >
-              <Image src={imgSrc} alt='가게 이미지' fill />
+              <Image objectFit='cover' src={imgSrc} alt='가게 이미지' fill />
             </Card>
           </SwiperSlide>
         ))}

--- a/src/components/store-detail/local-store/LocalStoreSection.tsx
+++ b/src/components/store-detail/local-store/LocalStoreSection.tsx
@@ -74,8 +74,8 @@ const LocalStoreSection = ({ storeDetailData }: LocalStoreSectionProps) => {
       <Box>
         <Box>
           <Typography variant='h5' fontWeight='bold' sx={{ mt: 10 }}>
-            {storeDetailData?.store_location} 지역 매물 |{' '}
-            {filteredData.length + '개'}
+            {storeDetailData?.store_location} 지역 매물
+            {/* {filteredData.length + '개'} */}
           </Typography>
           <Divider sx={{ my: 2 }} />
         </Box>

--- a/src/components/store-detail/pie-chart/StoreDetailPieChart.tsx
+++ b/src/components/store-detail/pie-chart/StoreDetailPieChart.tsx
@@ -16,8 +16,8 @@ const StoreDetailPieChart = ({
       }}
     >
       <PieChart
-        width={300}
-        height={300}
+        width={400}
+        height={400}
         series={[
           {
             data: parsedExpenditureData.map(([label, value], index) => ({

--- a/src/components/store-detail/pie-chart/StoreDetailPieChart.tsx
+++ b/src/components/store-detail/pie-chart/StoreDetailPieChart.tsx
@@ -1,5 +1,6 @@
 import Box from '@mui/material/Box';
 import { PieChart, pieArcLabelClasses } from '@mui/x-charts';
+import { convertMoneyString } from '@/utils';
 
 interface StoreDetailPieChartProps {
   parsedExpenditureData: [string, number][];
@@ -26,7 +27,9 @@ const StoreDetailPieChart = ({
               label,
             })),
             arcLabel: (item) =>
-              `${item.label} / ${item.value.toLocaleString('ko-KR')}`,
+              item.label === '월 수익'
+                ? `${item.label} / ${convertMoneyString(item.value)}`
+                : '',
             cornerRadius: 4,
             arcLabelMinAngle: 45,
             innerRadius: 30,

--- a/src/components/store-detail/pie-chart/StoreDetailWindow.tsx
+++ b/src/components/store-detail/pie-chart/StoreDetailWindow.tsx
@@ -41,6 +41,7 @@ const StoreDetailWindow = (props: StoreDetailWindowProps) => {
           fontWeight='bold'
           sx={{ borderBottom: '1px solid', borderColor: 'divider' }}
         >
+          [ 매물번호 {storeDetailData?.store_number} ]{' '}
           {storeDetailData?.store_name}
         </Typography>
         <Box>
@@ -94,7 +95,7 @@ const StoreDetailWindow = (props: StoreDetailWindowProps) => {
         initialValue={{
           location: storeDetailData?.store_location,
           category: storeDetailData?.store_category,
-          additional: `'${storeDetailData?.store_name}' 관련 문의`,
+          additional: `[ 매물번호 ${storeDetailData?.store_number} ] '${storeDetailData?.store_name}' 관련 문의`,
         }}
       />
     </>

--- a/src/components/store-detail/pie-chart/StoreDetailWindow.tsx
+++ b/src/components/store-detail/pie-chart/StoreDetailWindow.tsx
@@ -69,7 +69,7 @@ const StoreDetailWindow = (props: StoreDetailWindowProps) => {
             <Box>업종 : {storeDetailData?.store_category}</Box>
             <Box>
               면적 : {storeDetailData?.store_size}평 (
-              {storeDetailData?.store_size_m2} m2)
+              {storeDetailData?.store_size_m2}m<sup>2</sup>)
             </Box>
           </Box>
           <Box sx={{ my: 2 }}>

--- a/src/components/store-detail/store-detail-content/StoreDetailContent.tsx
+++ b/src/components/store-detail/store-detail-content/StoreDetailContent.tsx
@@ -118,7 +118,7 @@ const StoreDetailContent = ({
                 initialValue={{
                   location: storeDetailData?.store_location,
                   category: storeDetailData?.store_category,
-                  additional: `'${storeDetailData?.store_name}' 관련 문의`,
+                  additional: `[ 매물번호 ${storeDetailData?.store_number} ] '${storeDetailData?.store_name}' 관련 문의`,
                 }}
               />
             </Box>

--- a/src/components/store-detail/store-detail-content/StoreDetailContent.tsx
+++ b/src/components/store-detail/store-detail-content/StoreDetailContent.tsx
@@ -48,7 +48,13 @@ const StoreDetailContent = ({
           alignItems: 'center',
         }}
       >
-        <ImageSection imgSrcArr={storeDetailData?.store_img_src_arr} />
+        <ImageSection
+          imgSrcArr={
+            storeDetailData?.store_img_src_arr
+              ? storeDetailData?.store_img_src_arr
+              : ['/core-icon.png']
+          }
+        />
         {!isDownLarge && (
           <SalesDetailSection storeDetailData={storeDetailData} />
         )}

--- a/src/components/store-detail/store-detail-content/StoreDetailContent.tsx
+++ b/src/components/store-detail/store-detail-content/StoreDetailContent.tsx
@@ -52,7 +52,7 @@ const StoreDetailContent = ({
           imgSrcArr={
             storeDetailData?.store_img_src_arr
               ? storeDetailData?.store_img_src_arr
-              : ['/core-icon.png']
+              : [undefined]
           }
         />
         {!isDownLarge && (

--- a/src/components/store/StoreCards.tsx
+++ b/src/components/store/StoreCards.tsx
@@ -9,6 +9,7 @@ import { MobileStoreCard } from '../common/mobile-store-card';
 
 interface StoreCardsProps {
   storeData: Store[];
+  isLoading?: boolean;
   handleStoreChange: (newStoreName?: string) => void;
   openModal?: () => void;
   onCardClick?: () => void;

--- a/src/components/store/StoreCards.tsx
+++ b/src/components/store/StoreCards.tsx
@@ -2,7 +2,6 @@
 
 import { useMediaQuery, useTheme } from '@mui/material';
 import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
 import { Store } from '@/api/store';
 import { StoreCard } from '@/components/common/store-card';
 import { MobileStoreCard } from '../common/mobile-store-card';
@@ -16,6 +15,7 @@ interface StoreCardsProps {
 }
 const StoreCards = ({
   storeData,
+  isLoading,
   handleStoreChange,
   openModal,
   onCardClick,
@@ -27,7 +27,7 @@ const StoreCards = ({
     <Box
       sx={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 2 }}
     >
-      <Typography>{storeData.length}개의 검색결과</Typography>
+      {/* <Typography>{storeData.length}개의 검색결과</Typography> */}
       <Box
         sx={{
           width: '100%',
@@ -46,6 +46,7 @@ const StoreCards = ({
             <StoreCard
               key={'store-card' + index + ', id-' + store.store_id}
               storeData={store}
+              isLoading={isLoading}
               handleStoreChange={handleStoreChange}
               openModal={openModal}
               onCardClick={onCardClick}

--- a/src/components/store/StoreData.tsx
+++ b/src/components/store/StoreData.tsx
@@ -37,7 +37,7 @@ const StoreData = ({
   handleStoreChange,
   openModal,
 }: StoreDataProps) => {
-  const { data } = useGetStore(searchParams);
+  const { data, isLoading } = useGetStore(searchParams);
   const storeData = data?.data;
 
   const [isBackdrop, setIsBackdrop] = useState(false);
@@ -70,6 +70,7 @@ const StoreData = ({
       <Suspense fallback={<StoreResultLoading />}>
         <StoreCards
           storeData={storeData}
+          isLoading={isLoading}
           handleStoreChange={handleStoreChange}
           openModal={openModal}
           onCardClick={onCardClick}

--- a/src/components/store/StoreSearch.tsx
+++ b/src/components/store/StoreSearch.tsx
@@ -212,7 +212,7 @@ const StoreSearch = () => {
           fullWidth
           size={isDownMedium ? 'small' : 'medium'}
           variant='filled'
-          label='매물 이름'
+          label='매물 이름 / 설명 / 매물 번호'
           placeholder='매물 전체'
         />
         <Button

--- a/src/components/store/constants.ts
+++ b/src/components/store/constants.ts
@@ -64,6 +64,7 @@ export interface StoreBudgetData {
   value: string;
 }
 export enum StoreBudgetValue {
+  EMPTY = '',
   LESS_THAN_FIVE_THOUSAND = '0,5000',
   FIVE_THOUSAND_TO_ONE_BILLION = '5000,10000',
   ONE_BILLION_TO_TWO_BILLION = '10000,20000',
@@ -71,6 +72,7 @@ export enum StoreBudgetValue {
   THREE_BILLION_MORE = '30000,0',
 }
 export enum StoreBudgetLabel {
+  EMPTY = '',
   LESS_THAN_FIVE_THOUSAND = '5,000만 원 이하',
   FIVE_THOUSAND_TO_ONE_BILLION = '5,000만 원 ~ 1억 원',
   ONE_BILLION_TO_TWO_BILLION = '1억 원 ~ 2억 원',
@@ -85,6 +87,7 @@ export const STORE_BUDGET_DATA_ARR: StoreBudgetValue[] = [
   StoreBudgetValue.THREE_BILLION_MORE,
 ];
 export const STORE_BUDGET_MAPPER: Record<string, StoreBudgetLabel> = {
+  [StoreBudgetValue.EMPTY]: StoreBudgetLabel.EMPTY,
   [StoreBudgetValue.LESS_THAN_FIVE_THOUSAND]:
     StoreBudgetLabel.LESS_THAN_FIVE_THOUSAND,
   [StoreBudgetValue.FIVE_THOUSAND_TO_ONE_BILLION]:


### PR DESCRIPTION
# 작업내용
- 기본 이미지 & 라벨 추가
- 예산에 카테고리 들어가있는 버그 수정
<img width="839" alt="image" src="https://github.com/vangona/core-point-next/assets/69471032/e4f8d5ab-e82a-4c19-9dad-83983391446a">

- 데이터 개수 삭제
<img width="936" alt="image" src="https://github.com/vangona/core-point-next/assets/69471032/08ab6f5e-130f-4e92-b817-c5d588451b2f">
<img width="1250" alt="image" src="https://github.com/vangona/core-point-next/assets/69471032/28d326e5-022d-4fb1-acba-a03694a74bdf">

- 매물 페이지 매물번호 추가
<img width="935" alt="image" src="https://github.com/vangona/core-point-next/assets/69471032/ad87800b-d5cf-4df6-a958-0f7be71c29d9">
<img width="840" alt="image" src="https://github.com/vangona/core-point-next/assets/69471032/ab51d3ce-4e58-47be-9ac9-540a6336da2c">

- 매물 세부정보 페이지 매물번호 추가
<img width="722" alt="image" src="https://github.com/vangona/core-point-next/assets/69471032/20a6350a-e484-4d61-9484-d51eb0e7d13b">

- 메인 페이지 매물번호 추가
<img width="1087" alt="image" src="https://github.com/vangona/core-point-next/assets/69471032/ab4f6613-0ed9-473b-917d-424e9ec57e2d">

- 관리자 페이지 매물번호 추가
<img width="1127" alt="image" src="https://github.com/vangona/core-point-next/assets/69471032/6633fcfc-928e-429c-a729-da1cece20f6c">

- 매물번호, 설명 검색 기능 추가
<img width="1275" alt="image" src="https://github.com/vangona/core-point-next/assets/69471032/db5236ec-543f-4918-815c-5e6fb61d53bb">

- 파이차트 크기 변경
- 파이차트에 월 수익 추가
- 파이차트 월 수익 라벨만 렌더링 되도록 수정
<img width="702" alt="image" src="https://github.com/vangona/core-point-next/assets/69471032/5646d150-9a55-4d91-9121-37288445916d">

- 매물 세부정보 페이지에서 빈 배열시 아무 이미지가 나오지 않는 버그 수정
<img width="1227" alt="image" src="https://github.com/vangona/core-point-next/assets/69471032/d0bed09f-6cca-499b-9eda-62c64148a3db">

- 누락된 m2 추가
<img width="932" alt="image" src="https://github.com/vangona/core-point-next/assets/69471032/08c3d334-e258-4c98-901a-d832a062af4c">
